### PR TITLE
仕様変更 / コンテキストメニューの「作業状態初期化」を「初期化」に置き換え

### DIFF
--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -135,9 +135,12 @@
 
             <ListView.Resources>
                 <ContextMenu x:Key="listViewContextMenu">
-                    <MenuItem Header="作業状態を初期化" 
-                              Command="{Binding ResetWorkingStatusCommand}"
-                              />
+
+                    <MenuItem Header="初期化">
+                        <MenuItem Header="作業状態を初期化" 
+                                  Command="{Binding ResetWorkingStatusCommand}"
+                                  />
+                    </MenuItem>
 
                     <MenuItem Header="この Todo から新しい Todo を生成する"
                               Command="{Binding Path=DataContext.DatabaseHelper.CopyTodoCommand,


### PR DESCRIPTION
「初期化」自体には機能はなく、内部に「作業状態を初期化」を格納するためのメニューアイテムとなっている。
これにより、誤ってタスクの初期化を行うことを防止する

close #21
