### PR TITLE
Todoの日時フィルタリング機能を実装

### DIFF
--- a/WebTodoApp/Models/SQLCommandOption.cs
+++ b/WebTodoApp/Models/SQLCommandOption.cs
@@ -54,6 +54,22 @@ namespace WebTodoApp.Models {
         /// </summary>
         public int DisplayDateRange { get; set; }
 
+        public string DisplayDateRangeString {
+            get => displayDateRangeString;
+            set {
+                if(int.TryParse(value,out int result)) {
+                    DisplayDateRange = result;
+                }
+                else {
+                    DisplayDateRange = 0;
+                }
+
+                displayDateRangeString = DisplayDateRange.ToString();
+            }
+        }
+
+        private string displayDateRangeString = "0";
+
         public class SQLCommandColumnOption {
             public string Name { get; set; }
             public bool DESC { get; set; }

--- a/WebTodoApp/Models/SQLCommandOption.cs
+++ b/WebTodoApp/Models/SQLCommandOption.cs
@@ -20,8 +20,15 @@ namespace WebTodoApp.Models {
         public string buildSQL() {
             var sql = $"select * from {TableName} ";
 
+            sql += "where 1=1 ";
+
             if (ShowOnlyIncompleteTodo) {
-                sql += $"where {nameof(Todo.Completed)} = false ";
+                sql += $"AND {nameof(Todo.Completed)} = false ";
+            }
+
+            if(DisplayDateRange > 0) {
+                var pastDate = DateTime.Now - new TimeSpan(24 * DisplayDateRange, 0, 0);
+                sql += $"AND {nameof(Todo.CreationDate)} >= '{pastDate}' ";
             }
 
             if(OrderByColumns.Count > 0) {
@@ -39,6 +46,13 @@ namespace WebTodoApp.Models {
 
             return sql;
         }
+
+        /// <summary>
+        /// このプロパティにセットされた整数日前から Todo を表示するよう設定します。
+        /// 例えば 1 をセットした場合、その時の日付から、作成日時が一日前までの Todo を検索するSQLを生成します。
+        /// デフォルトは 0 となっており、この場合は全ての期間の Todo を指定します。
+        /// </summary>
+        public int DisplayDateRange { get; set; }
 
         public class SQLCommandColumnOption {
             public string Name { get; set; }

--- a/WebTodoApp/Models/TextInputLimitBehavior.cs
+++ b/WebTodoApp/Models/TextInputLimitBehavior.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interactivity;
+
+namespace WebTodoApp.Models {
+    public class TextInputLimitBehavior : Behavior<TextBox>{
+
+        protected override void OnAttached() {
+            base.OnAttached();
+            ((TextBox)AssociatedObject).PreviewTextInput += previewTextInputEventHandler;
+        }
+
+        protected override void OnDetaching() {
+            base.OnDetaching();
+            ((TextBox)AssociatedObject).PreviewTextInput -= previewTextInputEventHandler;
+        }
+
+        //イベントハンドラ
+        private void previewTextInputEventHandler(object sender, TextCompositionEventArgs e) {
+            if(!int.TryParse(e.Text, out int result)) {
+                e.Handled = true;
+            }
+        }
+    }
+
+}

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -88,7 +88,6 @@
                           Command="{Binding DatabaseHelper.TryFirstConnectCommand}"
                           />
             </MenuItem>
-
         </Menu>
 
         <ToolBar Grid.Row="1">
@@ -127,6 +126,21 @@
                            />
 
             </ToggleButton>
+
+            <TextBlock Text="日時指定 : "
+                       Margin="6,3"
+                       />
+
+            <TextBox Text="{Binding DatabaseHelper.SqlCommandOption.DisplayDateRange, UpdateSourceTrigger=PropertyChanged}"
+                     TextAlignment="Center"
+                     MinWidth="30"
+                     />
+
+            <TextBlock Text="日前まで表示"
+                       Margin="6,3"
+                       />
+
+
         </ToolBar>
 
         <ListView ItemsSource="{Binding DatabaseHelper.TodoList}"

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -134,7 +134,13 @@
             <TextBox Text="{Binding DatabaseHelper.SqlCommandOption.DisplayDateRange, UpdateSourceTrigger=PropertyChanged}"
                      TextAlignment="Center"
                      MinWidth="30"
-                     />
+                     >
+                <i:Interaction.Behaviors>
+                    <m:TextInputLimitBehavior/>
+                </i:Interaction.Behaviors>
+
+            </TextBox>
+
 
             <TextBlock Text="日前まで表示"
                        Margin="6,3"

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -131,7 +131,8 @@
                        Margin="6,3"
                        />
 
-            <TextBox Text="{Binding DatabaseHelper.SqlCommandOption.DisplayDateRange, UpdateSourceTrigger=PropertyChanged}"
+            <TextBox Text="{Binding DatabaseHelper.SqlCommandOption.DisplayDateRangeString,
+                UpdateSourceTrigger=PropertyChanged}"
                      TextAlignment="Center"
                      MinWidth="30"
                      >

--- a/WebTodoApp/WebTodoApp.csproj
+++ b/WebTodoApp/WebTodoApp.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Models\DBHelper.cs" />
     <Compile Include="Models\KeyDownBehavior.cs" />
     <Compile Include="Models\SQLCommandOption.cs" />
+    <Compile Include="Models\TextInputLimitBehavior.cs" />
     <Compile Include="Models\TextBoxROChangeBehavior.cs" />
     <Compile Include="Models\Todo.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />

--- a/WebTodoAppTests/Models/SQLCommandOptionTests.cs
+++ b/WebTodoAppTests/Models/SQLCommandOptionTests.cs
@@ -32,7 +32,7 @@ namespace WebTodoApp.Models.Tests {
 
             Assert.AreEqual(
                 commandOption.buildSQL(),
-                "select * from testTableName order by firstColumn DESC ,secondColumn DESC LIMIT 20;"
+                "select * from testTableName where 1=1 order by firstColumn DESC ,secondColumn DESC LIMIT 20;"
             );
 
         }


### PR DESCRIPTION
- 機能追加 / 指定日時以降の Todo を検索する機能を追加
- UI変更 / 日時範囲を入力するテキストボックスを追加
- 機能追加 / 日時範囲を入力するボックスに数値以外入力できないよう変更
- 仕様変更 / 日時指定のプロパティを数値と文字列に分離

close #27
