### PR TITLE
20210330#63 デザイン変更

### DIFF
--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -510,7 +510,11 @@
 
         </ListView>
 
-        <TabControl Grid.Row="4">
+        <TabControl
+            Grid.Row="4"
+            Background="{StaticResource darkBackgroundBrush}"
+            BorderThickness="0">
+
             <TabControl.Resources>
                 <Style
                     x:Key="tabItemTextBoxStyle"
@@ -519,10 +523,14 @@
                     <Setter Property="BorderBrush" Value="DarkGray" />
                     <Setter Property="BorderThickness" Value="0.5" />
                 </Style>
+
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
+                </Style>
+
             </TabControl.Resources>
 
-            <TabItem Header="Todo">
-
+            <TabItem Background="{StaticResource lightBackgroundBrush}" Header="Todo">
 
                 <DockPanel>
 
@@ -584,7 +592,13 @@
 
         </TabControl>
 
-        <StatusBar Grid.Row="6">
+        <StatusBar Grid.Row="6" Background="{StaticResource darkBackgroundBrush}">
+            <StatusBar.Resources>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
+                </Style>
+
+            </StatusBar.Resources>
 
             <StatusBarItem Grid.Column="0">
                 <TextBlock Text="{Binding DatabaseHelper.Message}" />

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -510,12 +510,14 @@
 
         </ListView>
 
-        <TabControl
-            Grid.Row="4"
-            Background="{StaticResource darkBackgroundBrush}"
-            BorderThickness="0">
 
-            <TabControl.Resources>
+
+
+
+        <DockPanel Grid.Row="4" Background="{StaticResource darkBackgroundBrush}">
+
+            <DockPanel.Resources>
+
                 <Style
                     x:Key="tabItemTextBoxStyle"
                     BasedOn="{StaticResource {x:Type TextBox}}"
@@ -527,70 +529,62 @@
                 <Style TargetType="TextBlock">
                     <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
                 </Style>
+            </DockPanel.Resources>
 
-            </TabControl.Resources>
 
-            <TabItem Background="{StaticResource lightBackgroundBrush}" Header="Todo">
+            <Grid Margin="0,3" DockPanel.Dock="Top">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="7*" />
+                </Grid.ColumnDefinitions>
 
-                <DockPanel>
+                <TextBlock
+                    Grid.Column="0"
+                    HorizontalAlignment="Right"
+                    Text="Priority : " />
 
-                    <Grid Margin="0,3" DockPanel.Dock="Top">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                            <ColumnDefinition Width="7*" />
-                        </Grid.ColumnDefinitions>
+                <TextBox
+                    x:Name="PriorityInputTextBox"
+                    Grid.Column="1"
+                    Style="{StaticResource tabItemTextBoxStyle}"
+                    Text="{Binding EnteringTodo.Priority}" />
 
-                        <TextBlock
-                            Grid.Column="0"
-                            HorizontalAlignment="Right"
-                            Text="Priority : " />
+                <TextBlock
+                    Grid.Column="2"
+                    HorizontalAlignment="Right"
+                    Text="Duration : " />
 
-                        <TextBox
-                            x:Name="PriorityInputTextBox"
-                            Grid.Column="1"
-                            Style="{StaticResource tabItemTextBoxStyle}"
-                            Text="{Binding EnteringTodo.Priority}" />
+                <TextBox
+                    Grid.Column="3"
+                    Style="{StaticResource tabItemTextBoxStyle}"
+                    Text="{Binding EnteringTodo.Duration}" />
 
-                        <TextBlock
-                            Grid.Column="2"
-                            HorizontalAlignment="Right"
-                            Text="Duration : " />
+                <TextBlock
+                    Grid.Column="4"
+                    HorizontalAlignment="Right"
+                    Text="Title : " />
 
-                        <TextBox
-                            Grid.Column="3"
-                            Style="{StaticResource tabItemTextBoxStyle}"
-                            Text="{Binding EnteringTodo.Duration}" />
+                <TextBox
+                    Grid.Column="5"
+                    HorizontalAlignment="Stretch"
+                    Style="{StaticResource tabItemTextBoxStyle}"
+                    Text="{Binding EnteringTodo.Title, UpdateSourceTrigger=PropertyChanged}" />
 
-                        <TextBlock
-                            Grid.Column="4"
-                            HorizontalAlignment="Right"
-                            Text="Title : " />
+            </Grid>
 
-                        <TextBox
-                            Grid.Column="5"
-                            HorizontalAlignment="Stretch"
-                            Style="{StaticResource tabItemTextBoxStyle}"
-                            Text="{Binding EnteringTodo.Title, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBox
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                AcceptsReturn="True"
+                DockPanel.Dock="Bottom"
+                Style="{StaticResource tabItemTextBoxStyle}"
+                Text="{Binding EnteringTodo.TextContent, UpdateSourceTrigger=PropertyChanged}" />
 
-                    </Grid>
-
-                    <TextBox
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        AcceptsReturn="True"
-                        DockPanel.Dock="Bottom"
-                        Style="{StaticResource tabItemTextBoxStyle}"
-                        Text="{Binding EnteringTodo.TextContent, UpdateSourceTrigger=PropertyChanged}" />
-
-                </DockPanel>
-
-            </TabItem>
-
-        </TabControl>
+        </DockPanel>
 
         <StatusBar Grid.Row="6" Background="{StaticResource darkBackgroundBrush}">
             <StatusBar.Resources>

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -14,6 +14,8 @@
     d:DataContext="{d:DesignInstance vms:MainWindowViewModel,
                                      IsDesignTimeCreatable=True}"
     prism:ViewModelLocator.AutoWireViewModel="True"
+    BorderBrush="Black"
+    BorderThickness="2"
     mc:Ignorable="d">
 
     <Window.Resources>

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -25,6 +25,7 @@
                 <ResourceDictionary Source="../res/Dictionary1.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <SolidColorBrush x:Key="darkBackgroundBrush_b" Color="#333333" />
             <SolidColorBrush x:Key="darkBackgroundBrush" Color="#444444" />
             <SolidColorBrush x:Key="mediumLightBackgroundBrush" Color="#777777" />
             <SolidColorBrush x:Key="lightBackgroundBrush" Color="#aaaaaa" />
@@ -279,15 +280,14 @@
             <ListView.ItemContainerStyle>
                 <Style BasedOn="{StaticResource ListViewItemContainerStyle}" TargetType="ListViewItem">
                     <Setter Property="ContextMenu" Value="{StaticResource listViewContextMenu}" />
-
                     <Style.Triggers>
 
                         <DataTrigger Binding="{Binding Completed}" Value="True">
-                            <Setter Property="Background" Value="{StaticResource darkBackgroundBrush}" />
+                            <Setter Property="Background" Value="{StaticResource darkBackgroundBrush_b}" />
                         </DataTrigger>
 
                         <DataTrigger Binding="{Binding Completed}" Value="False">
-                            <Setter Property="Background" Value="{StaticResource mediumLightBackgroundBrush}" />
+                            <Setter Property="Background" Value="{StaticResource darkBackgroundBrush}" />
                         </DataTrigger>
 
                     </Style.Triggers>

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -98,24 +98,43 @@
         </Grid.RowDefinitions>
         <ContentControl prism:RegionManager.RegionName="ContentRegion" />
 
-        <Menu Grid.Row="0">
-            <MenuItem Header="ファイル">
-                <MenuItem Command="{Binding DatabaseHelper.ExportAllCommand}" Header="全てのTodoを出力" />
+        <Menu
+            Grid.Row="0"
+            Background="{StaticResource darkBackgroundBrush}"
+            Foreground="{StaticResource lightForegroundBrush}">
 
-                <MenuItem Command="{Binding ExitCommand}" Header="終了" />
+            <MenuItem Header="ファイル">
+                <MenuItem
+                    Command="{Binding DatabaseHelper.ExportAllCommand}"
+                    Foreground="Black"
+                    Header="全てのTodoを出力" />
+
+                <MenuItem
+                    Command="{Binding ExitCommand}"
+                    Foreground="Black"
+                    Header="終了" />
 
             </MenuItem>
 
             <MenuItem Header="接続">
-                <MenuItem Command="{Binding DatabaseHelper.TryFirstConnectCommand}" Header="再接続" />
+                <MenuItem
+                    Command="{Binding DatabaseHelper.TryFirstConnectCommand}"
+                    Foreground="Black"
+                    Header="再接続" />
 
-                <MenuItem Command="{Binding ChangeDatabaseServerCommand}" Header="RDSに接続">
+                <MenuItem
+                    Command="{Binding ChangeDatabaseServerCommand}"
+                    Foreground="Black"
+                    Header="RDSに接続">
                     <MenuItem.CommandParameter>
                         <m:RDSConnectionStrings />
                     </MenuItem.CommandParameter>
                 </MenuItem>
 
-                <MenuItem Command="{Binding ChangeDatabaseServerCommand}" Header="EC2に接続">
+                <MenuItem
+                    Command="{Binding ChangeDatabaseServerCommand}"
+                    Foreground="Black"
+                    Header="EC2に接続">
                     <MenuItem.CommandParameter>
                         <m:EC2ConnectionStrings />
                     </MenuItem.CommandParameter>
@@ -205,8 +224,6 @@
                     <KeyBinding Key="Enter" Command="{Binding DatabaseHelper.LoadCommand}" />
                 </TextBox.InputBindings>
             </TextBox>
-
-
 
         </Grid>
 

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -124,63 +124,82 @@
             </MenuItem>
         </Menu>
 
-        <ToolBar Grid.Row="1">
-            <ToolBar.Resources>
+        <Grid Grid.Row="1" Background="{StaticResource darkBackgroundBrush}">
+
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Grid.Resources>
+
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
+                </Style>
                 <Style x:Key="opacityTextBlockStyle" TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="Black" />
+
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=ToggleButton}, Path=IsChecked}" Value="False">
                             <Setter Property="Opacity" Value="0.4" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
-            </ToolBar.Resources>
+            </Grid.Resources>
 
-            <ToggleButton
-                Margin="4,0"
-                BorderBrush="Azure"
-                Command="{Binding DatabaseHelper.LoadCommand}"
-                IsChecked="{Binding DatabaseHelper.SqlCommandOption.ShowOnlyIncompleteTodo}">
+            <StackPanel Grid.Column="0" Orientation="Horizontal">
 
-                <TextBlock Style="{StaticResource opacityTextBlockStyle}" Text="未完了のみ表示" />
+                <ToggleButton
+                    BorderBrush="Azure"
+                    Command="{Binding DatabaseHelper.LoadCommand}"
+                    IsChecked="{Binding DatabaseHelper.SqlCommandOption.ShowOnlyIncompleteTodo}">
 
-            </ToggleButton>
+                    <TextBlock Style="{StaticResource opacityTextBlockStyle}" Text="未完了のみ表示" />
 
-            <ToggleButton
-                Margin="4,0"
-                BorderBrush="LightBlue"
-                BorderThickness="1,0,1,0"
-                Command="{Binding ToggleTextContentVisibilityCommand}"
-                IsChecked="True">
+                </ToggleButton>
 
-                <TextBlock Style="{StaticResource opacityTextBlockStyle}" Text="一行表示" />
+                <ToggleButton
+                    Margin="4,0"
+                    BorderBrush="LightBlue"
+                    BorderThickness="1,0,1,0"
+                    Command="{Binding ToggleTextContentVisibilityCommand}"
+                    IsChecked="True">
 
-            </ToggleButton>
+                    <TextBlock Style="{StaticResource opacityTextBlockStyle}" Text="一行表示" />
 
-            <TextBlock Margin="6,3" Text="日時指定 : " />
+                </ToggleButton>
 
-            <TextBox
-                MinWidth="30"
-                Text="{Binding DatabaseHelper.SqlCommandOption.DisplayDateRangeString, UpdateSourceTrigger=PropertyChanged}"
-                TextAlignment="Center">
-                <i:Interaction.Behaviors>
-                    <m:TextInputLimitBehavior />
-                </i:Interaction.Behaviors>
+                <TextBlock Margin="6,3" Text="日時指定 : " />
 
-            </TextBox>
+                <TextBox
+                    MinWidth="30"
+                    Background="{StaticResource lightBackgroundBrush}"
+                    BorderThickness="0"
+                    Text="{Binding DatabaseHelper.SqlCommandOption.DisplayDateRangeString, UpdateSourceTrigger=PropertyChanged}"
+                    TextAlignment="Center">
+                    <i:Interaction.Behaviors>
+                        <m:TextInputLimitBehavior />
+                    </i:Interaction.Behaviors>
+
+                </TextBox>
 
 
-            <TextBlock Margin="6,3" Text="日前まで表示" />
+                <TextBlock Margin="6,3" Text="日前まで表示" />
 
-            <Border
-                Width="1"
-                Margin="3,0"
-                Background="Black" />
+                <Border
+                    Width="1"
+                    Margin="3,1"
+                    Background="Black" />
 
-            <TextBlock Margin="6,3" Text="テキスト検索 : " />
+                <TextBlock Margin="6,3" Text="テキスト検索 : " />
+
+            </StackPanel>
 
             <TextBox
                 x:Name="searchTextBox"
-                Width="200"
+                Grid.Column="1"
+                Background="{StaticResource lightBackgroundBrush}"
+                BorderThickness="0"
                 Text="{Binding DatabaseHelper.SqlCommandOption.SearchString, UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.InputBindings>
                     <KeyBinding Key="Enter" Command="{Binding DatabaseHelper.LoadCommand}" />
@@ -189,7 +208,7 @@
 
 
 
-        </ToolBar>
+        </Grid>
 
         <ListView
             x:Name="todoListView"

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -23,8 +23,13 @@
                 <ResourceDictionary Source="../res/Dictionary1.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <SolidColorBrush x:Key="darkBackgroundBrush" Color="#444444" />
+            <SolidColorBrush x:Key="mediumLightBackgroundBrush" Color="#777777" />
+            <SolidColorBrush x:Key="lightBackgroundBrush" Color="#aaaaaa" />
+            <SolidColorBrush x:Key="lightForegroundBrush" Color="WhiteSmoke" />
+
             <Style TargetType="TextBox">
-                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Background" Value="{StaticResource ResourceKey=lightBackgroundBrush}" />
                 <Setter Property="BorderBrush" Value="Transparent" />
                 <Setter Property="BorderThickness" Value="0" />
             </Style>
@@ -32,7 +37,7 @@
             <ControlTemplate x:Key="radiusButtonTemplate" TargetType="ToggleButton">
                 <Border
                     x:Name="border"
-                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderBrush="{StaticResource lightBackgroundBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="4">
                     <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
@@ -189,9 +194,11 @@
         <ListView
             x:Name="todoListView"
             Grid.Row="2"
+            Background="{StaticResource ResourceKey=darkBackgroundBrush}"
             ItemsSource="{Binding DatabaseHelper.TodoList}">
 
             <ListView.Resources>
+
                 <ContextMenu x:Key="listViewContextMenu">
 
                     <MenuItem Header="初期化">
@@ -251,11 +258,11 @@
                     <Style.Triggers>
 
                         <DataTrigger Binding="{Binding Completed}" Value="True">
-                            <Setter Property="Background" Value="White" />
+                            <Setter Property="Background" Value="{StaticResource darkBackgroundBrush}" />
                         </DataTrigger>
 
                         <DataTrigger Binding="{Binding Completed}" Value="False">
-                            <Setter Property="Background" Value="AliceBlue" />
+                            <Setter Property="Background" Value="{StaticResource mediumLightBackgroundBrush}" />
                         </DataTrigger>
 
                     </Style.Triggers>
@@ -267,6 +274,12 @@
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <DockPanel>
+                        <DockPanel.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
+                            </Style>
+                        </DockPanel.Resources>
+
                         <DockPanel.InputBindings>
                             <KeyBinding
                                 Key="Return"
@@ -282,11 +295,6 @@
                             Text="{Binding Priority}"
                             TextAlignment="Center" />
 
-                        <Border
-                            Height="2"
-                            Background="AliceBlue"
-                            DockPanel.Dock="Top" />
-
                         <Grid Margin="0,2" DockPanel.Dock="Top">
 
                             <Grid.ColumnDefinitions>
@@ -301,7 +309,6 @@
                                 <RowDefinition />
                                 <RowDefinition />
                             </Grid.RowDefinitions>
-
 
                             <CheckBox
                                 Grid.Column="0"
@@ -327,7 +334,6 @@
                                         </Style.Triggers>
                                     </Style>
                                 </CheckBox.Style>
-
                             </CheckBox>
 
                             <ToggleButton
@@ -343,12 +349,10 @@
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding Completed}" Value="True">
                                                 <Setter Property="Margin" Value="10" />
-                                                <Setter Property="BorderBrush" Value="WhiteSmoke" />
                                             </DataTrigger>
 
                                             <DataTrigger Binding="{Binding CanStart}" Value="False">
                                                 <Setter Property="Margin" Value="10" />
-                                                <Setter Property="BorderBrush" Value="WhiteSmoke" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -417,7 +421,6 @@
                                 <TextBox
                                     x:Name="titleTextBox"
                                     Margin="3,0"
-                                    Background="WhiteSmoke"
                                     BorderBrush="Black"
                                     IsReadOnly="True"
                                     Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}">
@@ -444,7 +447,6 @@
                                     Grid.Column="3"
                                     MinWidth="30"
                                     Margin="3,0"
-                                    Background="WhiteSmoke"
                                     IsReadOnly="True"
                                     Text="{Binding TextContent, UpdateSourceTrigger=PropertyChanged}"
                                     TextWrapping="NoWrap"
@@ -472,7 +474,7 @@
                                 MinWidth="30"
                                 Margin="2,1"
                                 HorizontalAlignment="Left"
-                                Background="WhiteSmoke"
+                                Background="{StaticResource mediumLightBackgroundBrush}"
                                 CornerRadius="3">
 
                                 <TextBox
@@ -482,7 +484,6 @@
                                     Margin="4,0"
                                     HorizontalAlignment="Left"
                                     AcceptsReturn="True"
-                                    Background="WhiteSmoke"
                                     IsReadOnly="True"
                                     Text="{Binding TextContent, UpdateSourceTrigger=PropertyChanged}"
                                     TextWrapping="Wrap"

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -36,6 +36,10 @@
                 <Setter Property="BorderThickness" Value="0" />
             </Style>
 
+            <Style TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
+            </Style>
+
             <ControlTemplate x:Key="radiusButtonTemplate" TargetType="ToggleButton">
                 <Border
                     x:Name="border"
@@ -139,9 +143,6 @@
 
             <Grid.Resources>
 
-                <Style TargetType="TextBlock">
-                    <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
-                </Style>
                 <Style x:Key="opacityTextBlockStyle" TargetType="TextBlock">
                     <Setter Property="Foreground" Value="Black" />
 
@@ -545,9 +546,6 @@
                     <Setter Property="BorderThickness" Value="0.5" />
                 </Style>
 
-                <Style TargetType="TextBlock">
-                    <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
-                </Style>
             </DockPanel.Resources>
 
 
@@ -606,12 +604,6 @@
         </DockPanel>
 
         <StatusBar Grid.Row="6" Background="{StaticResource darkBackgroundBrush}">
-            <StatusBar.Resources>
-                <Style TargetType="TextBlock">
-                    <Setter Property="Foreground" Value="{StaticResource lightForegroundBrush}" />
-                </Style>
-
-            </StatusBar.Resources>
 
             <StatusBarItem Grid.Column="0">
                 <TextBlock Text="{Binding DatabaseHelper.Message}" />

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -268,7 +268,6 @@
 
                     </Style.Triggers>
 
-
                 </Style>
             </ListView.ItemContainerStyle>
 
@@ -473,7 +472,7 @@
                                 Grid.Row="1"
                                 Grid.Column="2"
                                 MinWidth="30"
-                                Margin="2,1"
+                                Margin="0,1"
                                 HorizontalAlignment="Left"
                                 Background="{StaticResource mediumLightBackgroundBrush}"
                                 CornerRadius="3">
@@ -482,7 +481,7 @@
                                     Grid.Row="1"
                                     Grid.Column="2"
                                     MinWidth="{Binding ElementName=TextContentBoarder, Path=MinWidth}"
-                                    Margin="4,0"
+                                    Margin="3,0"
                                     HorizontalAlignment="Left"
                                     AcceptsReturn="True"
                                     IsReadOnly="True"
@@ -510,10 +509,6 @@
             </ListView.ItemTemplate>
 
         </ListView>
-
-
-
-
 
         <DockPanel Grid.Row="4" Background="{StaticResource darkBackgroundBrush}">
 

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -195,6 +195,7 @@
             x:Name="todoListView"
             Grid.Row="2"
             Background="{StaticResource ResourceKey=darkBackgroundBrush}"
+            BorderThickness="0"
             ItemsSource="{Binding DatabaseHelper.TodoList}">
 
             <ListView.Resources>

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -104,37 +104,22 @@
             Foreground="{StaticResource lightForegroundBrush}">
 
             <MenuItem Header="ファイル">
-                <MenuItem
-                    Command="{Binding DatabaseHelper.ExportAllCommand}"
-                    Foreground="Black"
-                    Header="全てのTodoを出力" />
+                <MenuItem Command="{Binding DatabaseHelper.ExportAllCommand}" Header="全てのTodoを出力" />
 
-                <MenuItem
-                    Command="{Binding ExitCommand}"
-                    Foreground="Black"
-                    Header="終了" />
+                <MenuItem Command="{Binding ExitCommand}" Header="終了" />
 
             </MenuItem>
 
             <MenuItem Header="接続">
-                <MenuItem
-                    Command="{Binding DatabaseHelper.TryFirstConnectCommand}"
-                    Foreground="Black"
-                    Header="再接続" />
+                <MenuItem Command="{Binding DatabaseHelper.TryFirstConnectCommand}" Header="再接続" />
 
-                <MenuItem
-                    Command="{Binding ChangeDatabaseServerCommand}"
-                    Foreground="Black"
-                    Header="RDSに接続">
+                <MenuItem Command="{Binding ChangeDatabaseServerCommand}" Header="RDSに接続">
                     <MenuItem.CommandParameter>
                         <m:RDSConnectionStrings />
                     </MenuItem.CommandParameter>
                 </MenuItem>
 
-                <MenuItem
-                    Command="{Binding ChangeDatabaseServerCommand}"
-                    Foreground="Black"
-                    Header="EC2に接続">
+                <MenuItem Command="{Binding ChangeDatabaseServerCommand}" Header="EC2に接続">
                     <MenuItem.CommandParameter>
                         <m:EC2ConnectionStrings />
                     </MenuItem.CommandParameter>

--- a/WebTodoApp/res/Dictionary1.xaml
+++ b/WebTodoApp/res/Dictionary1.xaml
@@ -1,6 +1,9 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    >
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+
+    <Color x:Key="DisabledForegroundColor">#FF888888</Color>
+
+    <Color x:Key="GlyphColor">#FF444444</Color>
 
     <Style x:Key="ListViewItemContainerStyle" TargetType="ListViewItem">
         <Setter Property="SnapsToDevicePixels" Value="true" />
@@ -8,11 +11,13 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListViewItem">
-                    <Border x:Name="Border"
-                            SnapsToDevicePixels="true"
-                            BorderBrush="Transparent"
-                            BorderThickness="1"
-                            Background="{TemplateBinding Background}">
+                    <Border
+                        x:Name="Border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="Transparent"
+                        BorderThickness="1"
+                        SnapsToDevicePixels="true">
+                        <ContentPresenter />
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -25,30 +30,229 @@
                                 <VisualState x:Name="Unselected" />
                                 <VisualState x:Name="Selected">
                                     <Storyboard>
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)">
-                                            <EasingColorKeyFrame KeyTime="0:0:0.2"
-                                         Value="Blue" />
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)">
+                                            <EasingColorKeyFrame KeyTime="0:0:0.2" Value="Blue" />
                                         </ColorAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
 
                                 <VisualState x:Name="SelectedUnfocused">
                                     <Storyboard>
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)">
-                                            <EasingColorKeyFrame KeyTime="0"
-                                         Value="LightBlue" />
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border" Storyboard.TargetProperty="(Border.BorderBrush).(SolidColorBrush.Color)">
+                                            <EasingColorKeyFrame KeyTime="0" Value="LightBlue" />
                                         </ColorAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <ContentPresenter/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <Style
+        x:Key="MenuScrollViewer"
+        BasedOn="{x:Null}"
+        TargetType="{x:Type ScrollViewer}">
+        <Setter Property="HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="VerticalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid SnapsToDevicePixels="True">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Border Grid.Row="1" Grid.Column="0">
+                            <ScrollContentPresenter />
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!--  TopLevelHeader  -->
+    <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="Border">
+            <Grid>
+                <ContentPresenter
+                    Margin="6,3,6,3"
+                    ContentSource="Header"
+                    RecognizesAccessKey="True" />
+                <Popup
+                    x:Name="Popup"
+                    AllowsTransparency="True"
+                    Focusable="False"
+                    IsOpen="{TemplateBinding IsSubmenuOpen}"
+                    Placement="Bottom"
+                    PopupAnimation="Fade">
+                    <Border
+                        x:Name="SubmenuBorder"
+                        Background="DimGray"
+                        BorderBrush="DimGray"
+                        BorderThickness="3"
+                        SnapsToDevicePixels="True">
+
+                        <ScrollViewer CanContentScroll="True" Style="{StaticResource MenuScrollViewer}">
+                            <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
+                        </ScrollViewer>
+
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsSuspendingPopupAnimation" Value="true">
+                <Setter TargetName="Popup" Property="PopupAnimation" Value="None" />
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="true">
+                <Setter TargetName="Border" Property="BorderBrush" Value="Transparent" />
+                <Setter TargetName="Border" Property="Background" Value="Gray" />
+            </Trigger>
+
+            <Trigger SourceName="Popup" Property="AllowsTransparency" Value="True">
+                <Setter TargetName="SubmenuBorder" Property="CornerRadius" Value="0,0,4,4" />
+                <Setter TargetName="SubmenuBorder" Property="Padding" Value="0,0,0,3" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{StaticResource DisabledForegroundColor}" />
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="{x:Static MenuItem.TopLevelItemTemplateKey}" TargetType="{x:Type MenuItem}">
+        <Border x:Name="Border">
+            <Grid>
+                <ContentPresenter ContentSource="Header" RecognizesAccessKey="True" />
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="true">
+                <Setter TargetName="Border" Property="Background" Value="LightBlue" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{StaticResource DisabledForegroundColor}" />
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!--  SubmenuItem  -->
+    <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
+        <Border
+            x:Name="Border"
+            Padding="0,3"
+            Background="DimGray"
+            BorderThickness="0">
+
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="Icon" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
+                    <ColumnDefinition Width="13" />
+                </Grid.ColumnDefinitions>
+
+                <ContentPresenter
+                    x:Name="Icon"
+                    Margin="6,0,6,0"
+                    VerticalAlignment="Center"
+                    ContentSource="Icon" />
+
+                <Border
+                    x:Name="Check"
+                    Width="13"
+                    Height="13"
+                    Margin="6,0,6,0"
+                    Background="AliceBlue"
+                    BorderThickness="0"
+                    Visibility="Collapsed">
+
+                    <Path
+                        x:Name="CheckMark"
+                        Width="7"
+                        Height="7"
+                        Data="M 0 0 L 7 7 M 0 7 L 7 0"
+                        SnapsToDevicePixels="False"
+                        StrokeThickness="2"
+                        Visibility="Hidden">
+                        <Path.Stroke>
+                            <SolidColorBrush Color="{DynamicResource GlyphColor}" />
+                        </Path.Stroke>
+                    </Path>
+                </Border>
+                <ContentPresenter
+                    x:Name="HeaderHost"
+                    Grid.Column="1"
+                    ContentSource="Header"
+                    RecognizesAccessKey="True" />
+                <TextBlock
+                    x:Name="InputGestureText"
+                    Grid.Column="2"
+                    DockPanel.Dock="Right"
+                    Text="{TemplateBinding InputGestureText}" />
+            </Grid>
+        </Border>
+
+        <ControlTemplate.Triggers>
+            <Trigger Property="ButtonBase.Command" Value="{x:Null}" />
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="Icon" Property="Visibility" Value="Hidden" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="true">
+                <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
+            </Trigger>
+            <Trigger Property="IsCheckable" Value="true">
+                <Setter TargetName="Check" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Hidden" />
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="true">
+                <Setter TargetName="Border" Property="Background" Value="SteelBlue" />
+                <Setter TargetName="Border" Property="BorderBrush" Value="SteelBlue" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground">
+                    <Setter.Value>
+                        <SolidColorBrush Color="{StaticResource DisabledForegroundColor}" />
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!--  MenuItem Style  -->
+    <Style x:Key="{x:Type MenuItem}" TargetType="{x:Type MenuItem}">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Style.Triggers>
+            <Trigger Property="Role" Value="TopLevelHeader">
+                <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.TopLevelHeaderTemplateKey}}" />
+                <Setter Property="Grid.IsSharedSizeScope" Value="true" />
+            </Trigger>
+            <Trigger Property="Role" Value="TopLevelItem">
+                <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.TopLevelItemTemplateKey}}" />
+            </Trigger>
+            <Trigger Property="Role" Value="SubmenuHeader">
+                <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.SubmenuHeaderTemplateKey}}" />
+            </Trigger>
+            <Trigger Property="Role" Value="SubmenuItem">
+                <Setter Property="Template" Value="{StaticResource {x:Static MenuItem.SubmenuItemTemplateKey}}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
- ListView と ListViewItem の背景、前景色を変更。
- タブコントロールの一部を除く部分、ステータスバーの配色を変更
- タブコントロールを削除し、中身をグリッドの直下に移動
- ListView ｎボーダーを削除
- ２行表示の差異、テキストブロックの位置にずれがあったため微調整
- ツールバーをグリッドに差し替えて配色を変更。
- メニューバーの背景色、前景色を変更。
- メニューバーのポップアップ部分のデザインを変更
- メインウィンドウに枠線を追加
- 複数箇所に散らばっていた無駄なスタイルを統括
- リストビュー内のスタイルの微調整

close #63
