### PR TITLE
20210508#81 新規Todoのラベル機能の実装

### DIFF
--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -314,9 +314,17 @@
                             x:Name="colorSelectComboBox"
                             Margin="3,0,0,0"
                             VerticalAlignment="Center"
+                            Background="{Binding LabelColor}"
                             DockPanel.Dock="Left"
                             ItemsSource="{Binding SelectableLableColors}"
                             SelectedIndex="{Binding SelectedColorIndex}">
+
+                            <ComboBox.Resources>
+                                <Style TargetType="ToggleButton">
+                                    <Setter Property="Background" Value="{Binding LabelColor}" />
+                                </Style>
+                            </ComboBox.Resources>
+
                             <i:Interaction.Triggers>
                                 <i:EventTrigger EventName="SelectionChanged">
                                     <i:InvokeCommandAction Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.DatabaseHelper.UpdateCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=ListViewItem}}" />
@@ -553,6 +561,7 @@
 
 
             <Grid Margin="0,3" DockPanel.Dock="Top">
+
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="300" />
                     <ColumnDefinition Width="50" />
@@ -562,9 +571,17 @@
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
 
                     <ComboBox
-                        Width="20"
-                        Background="Red"
-                        ItemsSource="{Binding EnteringTodo.SelectableLableColors}" />
+                        Width="25"
+                        Height="Auto"
+                        Margin="5,0"
+                        ItemsSource="{Binding EnteringTodo.SelectableLableColors}">
+
+                        <ComboBox.Resources>
+                            <Style TargetType="ToggleButton">
+                                <Setter Property="Background" Value="{Binding EnteringTodo.LabelColor}" />
+                            </Style>
+                        </ComboBox.Resources>
+                    </ComboBox>
 
                     <TextBlock Text="Priority : " />
 

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -554,45 +554,42 @@
 
             <Grid Margin="0,3" DockPanel.Dock="Top">
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="300" />
+                    <ColumnDefinition Width="50" />
                     <ColumnDefinition />
-                    <ColumnDefinition />
-                    <ColumnDefinition />
-                    <ColumnDefinition />
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="7*" />
                 </Grid.ColumnDefinitions>
 
-                <TextBlock
-                    Grid.Column="0"
-                    HorizontalAlignment="Right"
-                    Text="Priority : " />
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+
+                    <ComboBox
+                        Width="20"
+                        Background="Red"
+                        ItemsSource="{Binding EnteringTodo.SelectableLableColors}" />
+
+                    <TextBlock Text="Priority : " />
+
+                    <TextBox
+                        x:Name="PriorityInputTextBox"
+                        Width="100"
+                        Style="{StaticResource tabItemTextBoxStyle}"
+                        Text="{Binding EnteringTodo.Priority}" />
+
+                    <TextBlock Text="Duration : " />
+
+                    <TextBox
+                        Width="100"
+                        Style="{StaticResource tabItemTextBoxStyle}"
+                        Text="{Binding EnteringTodo.Duration}" />
+
+                </StackPanel>
+
+                <TextBlock Grid.Column="1" Text="Title : " />
 
                 <TextBox
-                    x:Name="PriorityInputTextBox"
-                    Grid.Column="1"
-                    Style="{StaticResource tabItemTextBoxStyle}"
-                    Text="{Binding EnteringTodo.Priority}" />
-
-                <TextBlock
                     Grid.Column="2"
-                    HorizontalAlignment="Right"
-                    Text="Duration : " />
-
-                <TextBox
-                    Grid.Column="3"
-                    Style="{StaticResource tabItemTextBoxStyle}"
-                    Text="{Binding EnteringTodo.Duration}" />
-
-                <TextBlock
-                    Grid.Column="4"
-                    HorizontalAlignment="Right"
-                    Text="Title : " />
-
-                <TextBox
-                    Grid.Column="5"
-                    HorizontalAlignment="Stretch"
                     Style="{StaticResource tabItemTextBoxStyle}"
                     Text="{Binding EnteringTodo.Title, UpdateSourceTrigger=PropertyChanged}" />
+
 
             </Grid>
 

--- a/WebTodoApp/Views/MainWindow.xaml
+++ b/WebTodoApp/Views/MainWindow.xaml
@@ -574,7 +574,8 @@
                         Width="25"
                         Height="Auto"
                         Margin="5,0"
-                        ItemsSource="{Binding EnteringTodo.SelectableLableColors}">
+                        ItemsSource="{Binding EnteringTodo.SelectableLableColors}"
+                        SelectedIndex="{Binding EnteringTodo.SelectedColorIndex}">
 
                         <ComboBox.Resources>
                             <Style TargetType="ToggleButton">

--- a/WebTodoApp/res/ColorSelectionComboBoxResource.xaml
+++ b/WebTodoApp/res/ColorSelectionComboBoxResource.xaml
@@ -54,7 +54,7 @@
             <Border
                 x:Name="Border"
                 Grid.ColumnSpan="2"
-                Background="{Binding LabelColor}"
+                Background="{TemplateBinding Background}"
                 BorderBrush="Transparent"
                 BorderThickness="1"
                 CornerRadius="3" />
@@ -95,7 +95,6 @@
         <Border
             x:Name="PART_ContentHost"
             Width="20"
-            Background="{TemplateBinding Background}"
             Focusable="False" />
     </ControlTemplate>
 


### PR DESCRIPTION
- 新規Todo の入力UI周りをグリッド内包からグリッドとスタックパネル内包に変更
- 新規作成するTodo の Priority の横にカラーラベル選択ボックスを追加
- ビューのカラーラベル選択ボックスとカラーラベルのインデックスをバインド

close #81
